### PR TITLE
feat: allow storageProvider to emit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # rds-contracts
+
+## message
+The `StorageProvider` can emit an arbitrary message in the function calls `setStorageOffer` and `emitMessage`. The message is is initially intended to allow the `StorageProvider` to communicate his `nodeID`, but may be used for other purposes later.
+
+The client should be instructed to enforce the following semantics:
+- If `message` starts with `0x01`, then the following bits contain an arbitrary length `nodeID`.

--- a/contracts/PinningManager.sol
+++ b/contracts/PinningManager.sol
@@ -87,7 +87,7 @@ contract PinningManager {
     @param maximumDuration the maximum time (in seconds) for which a proposer can prepay. Prepaid bids can't be cancelled REF1.
     @param periods the offered periods. Length must be equal to pricesForPeriods.
     @param pricesForPeriods the prices for the offered periods. Each entry at index corresponds to the same index at periods.
-    @param message the storageProvider may include a message (e.g. his nodeID). Message should be structured (e.g. first byte specifies message type, followed with message)
+    @param message the storageProvider may include a message (e.g. his nodeID).  Message should be structured such that the first two bits specify the message type, followed with the message). 0x01 == nodeID
     */
     function setStorageOffer(uint128 capacity,
         uint128 maximumDuration,
@@ -168,7 +168,7 @@ contract PinningManager {
     }
 
     /**
-    @param message the storageProvider may send a message (e.g. his nodeID). Message should be structured (e.g. first byte specifies message type, followed with message)
+    @param message the storageProvider may send a message (e.g. his nodeID). Message should be structured such that the first two bits specify the message type, followed with the message). 0x01 == nodeID
     */
     function emitMessage(bytes32[]memory message) public {
         _emitMessage(message);

--- a/contracts/PinningManager.sol
+++ b/contracts/PinningManager.sol
@@ -196,7 +196,7 @@ contract PinningManager {
         StorageOffer storage offer = offerRegistry[provider];
         Request storage request = offer.RequestRegistry[requestReference];
         // NO_OVERFLOW reasoning. See: REF_DURATION
-        bool isPastCurrentEndTime = (request.startDate + request.numberOfPeriodsDeposited) * request.chosenPeriod < now;
+        bool isPastCurrentEndTime = request.startDate + request.numberOfPeriodsDeposited * request.chosenPeriod < now;
         require(
             request.startDate == 0 ||
             isPastCurrentEndTime,


### PR DESCRIPTION
closes #18 
This can be used to emit nodeID. Advantage of having it generic is that is allows for updating and potentially other useful message which we haven't thought about yet.
The message should be structured and how it is structured should be documented by the client. E.g. first byte specifies the message type, where message type 1 is nodeID (len = Y bytes), message type n is Z, etc. 