### PR TITLE
fix: not indexed filereference

### DIFF
--- a/contracts/PinningManager.sol
+++ b/contracts/PinningManager.sol
@@ -54,7 +54,7 @@ contract PinningManager {
     event MessageEmitted(address indexed storer, bytes32[] message);
 
     event RequestMade(
-        bytes32[] indexed fileReference,
+        bytes32[] fileReference,
         address indexed requester,
         address indexed provider,
         uint128 size,


### PR DESCRIPTION
As dynamic sized arrays which are indexed are not emitted in Event, we
need to not-indexed fileReference in order to get the hash to be pinned.